### PR TITLE
Update respond_to? override to take second param.

### DIFF
--- a/lib/stamps.rb
+++ b/lib/stamps.rb
@@ -26,8 +26,8 @@ module Stamps
   end
 
   # Delegate to Stamps::Client
-  def self.respond_to?(method)
-    return client.respond_to?(method) || super
+  def self.respond_to?(method, include_all=false)
+    return client.respond_to?(method, include_all) || super
   end
 
 end


### PR DESCRIPTION
The second optional param is necessary, since anything that calls this
with more than one param would fail otherwise.
